### PR TITLE
Feature/itemtype

### DIFF
--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/ItemRequestActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/ItemRequestActivityTest.kt
@@ -25,7 +25,6 @@ import com.github.sdpteam15.polyevents.database.observe.ObservableList
 import com.github.sdpteam15.polyevents.fakedatabase.FakeDatabase
 import com.github.sdpteam15.polyevents.fakedatabase.FakeDatabaseItem
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.Description
 import org.hamcrest.TypeSafeMatcher
@@ -75,13 +74,13 @@ class ItemRequestActivityTest {
     @Before
     fun setup() {
         availableItems = mutableMapOf()
-        availableItems[Item(null, "Bananas", ItemType.OTHER)] = 30
-        availableItems[Item(null, "Kiwis", ItemType.OTHER)] = 10
-        availableItems[Item(null, "230V Plugs", ItemType.PLUG)] = 30
-        availableItems[Item(null, "Fridge (large)", ItemType.OTHER)] = 5
-        availableItems[Item(null, "Cord rewinder (15m)", ItemType.PLUG)] = 30
-        availableItems[Item(null, "Cord rewinder (50m)", ItemType.PLUG)] = 10
-        availableItems[Item(null, "Cord rewinder (25m)", ItemType.PLUG)] = 20
+        availableItems[Item(null, "Bananas", "OTHER")] = 30
+        availableItems[Item(null, "Kiwis", "OTHER")] = 10
+        availableItems[Item(null, "230V Plugs", "PLUG")] = 30
+        availableItems[Item(null, "Fridge (large)", "PLUG")] = 5
+        availableItems[Item(null, "Cord rewinder (15m)", "PLUG")] = 30
+        availableItems[Item(null, "Cord rewinder (50m)", "PLUG")] = 10
+        availableItems[Item(null, "Cord rewinder (25m)", "PLUG")] = 20
 
 
         // TODO : replace by the db interface call

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/ItemsAdminActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/ItemsAdminActivityTest.kt
@@ -15,7 +15,6 @@ import com.github.sdpteam15.polyevents.database.FirestoreDatabaseProvider
 import com.github.sdpteam15.polyevents.fakedatabase.FakeDatabase
 import com.github.sdpteam15.polyevents.fakedatabase.FakeDatabaseItem
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -25,7 +24,7 @@ class ItemsAdminActivityTest {
 
     lateinit var availableItems: MutableMap<Item, Int>
 
-    private val testItem = Item(null, "test item", ItemType.OTHER)
+    private val testItem = Item(null, "test item", "TESTITEMTYPE")
     private val testQuantity = 3
 
 
@@ -34,13 +33,13 @@ class ItemsAdminActivityTest {
     @Before
     fun setup() {
         availableItems = mutableMapOf()
-        availableItems[Item(null, "Chocolat", ItemType.OTHER)] = 30
-        availableItems[Item(null, "Kiwis", ItemType.OTHER)] = 10
-        availableItems[Item(null, "230V Plugs", ItemType.PLUG)] = 30
-        availableItems[Item(null, "Fridge (large)", ItemType.OTHER)] = 5
-        availableItems[Item(null, "Cord rewinder (15m)", ItemType.PLUG)] = 30
-        availableItems[Item(null, "Cord rewinder (50m)", ItemType.PLUG)] = 10
-        availableItems[Item(null, "Cord rewinder (25m)", ItemType.PLUG)] = 20
+        availableItems[Item(null, "Chocolat", "OTHER")] = 30
+        availableItems[Item(null, "Kiwis", "OTHER")] = 10
+        availableItems[Item(null, "230V Plugs", "OTHER")] = 30
+        availableItems[Item(null, "Fridge (large)", "OTHER")] = 5
+        availableItems[Item(null, "Cord rewinder (15m)", "OTHER")] = 30
+        availableItems[Item(null, "Cord rewinder (50m)", "OTHER")] = 10
+        availableItems[Item(null, "Cord rewinder (25m)", "OTHER")] = 20
 
 
         // TODO : replace by the db interface call

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/ItemsAdminActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/ItemsAdminActivityTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 class ItemsAdminActivityTest {
 
     lateinit var availableItems: MutableMap<Item, Int>
+    lateinit var availableItemTypes: MutableList<String>
 
     private val testItem = Item(null, "test item", "TESTITEMTYPE")
     private val testQuantity = 3
@@ -33,22 +34,28 @@ class ItemsAdminActivityTest {
     @Before
     fun setup() {
         availableItems = mutableMapOf()
-        availableItems[Item(null, "Chocolat", "OTHER")] = 30
-        availableItems[Item(null, "Kiwis", "OTHER")] = 10
-        availableItems[Item(null, "230V Plugs", "OTHER")] = 30
-        availableItems[Item(null, "Fridge (large)", "OTHER")] = 5
-        availableItems[Item(null, "Cord rewinder (15m)", "OTHER")] = 30
-        availableItems[Item(null, "Cord rewinder (50m)", "OTHER")] = 10
-        availableItems[Item(null, "Cord rewinder (25m)", "OTHER")] = 20
+        availableItems[Item(null, "Chocolat", "Food")] = 30
+        availableItems[Item(null, "Kiwis", "Food")] = 10
+        availableItems[Item(null, "230V Plugs", "Plug")] = 30
+        availableItems[Item(null, "Fridge (large)", "Fridge")] = 5
+        availableItems[Item(null, "Cord rewinder (15m)", "Plug")] = 30
+        availableItems[Item(null, "Cord rewinder (50m)", "Plug")] = 10
+        availableItems[Item(null, "Cord rewinder (25m)", "Plug")] = 20
 
+        availableItemTypes = mutableListOf("Food","Plug","Fridge")
 
-        // TODO : replace by the db interface call
         currentDatabase = FakeDatabase
 
         FakeDatabaseItem.items.clear()
         for ((item, count) in availableItems) {
             currentDatabase.itemDatabase!!.createItem(item, count)
         }
+
+        FakeDatabaseItem.itemTypes.clear()
+        for (itemType in availableItemTypes){
+            currentDatabase.itemDatabase!!.createItemType(itemType)
+        }
+
 
         val intent =
             Intent(ApplicationProvider.getApplicationContext(), ItemsAdminActivity::class.java)
@@ -60,7 +67,6 @@ class ItemsAdminActivityTest {
 
     @After
     fun tearDown() {
-        currentDatabase = FirestoreDatabaseProvider
         currentDatabase = FirestoreDatabaseProvider
     }
 
@@ -78,10 +84,13 @@ class ItemsAdminActivityTest {
         closeSoftKeyboard()
         onView(withId(R.id.id_edittext_item_quantity)).perform(typeText(testQuantity.toString()))
         closeSoftKeyboard()
+        onView(withId(R.id.id_edittext_item_type)).perform(typeText(testItem.itemType))
+        closeSoftKeyboard()
         onView(withId(R.id.id_confirm_add_item_button)).perform(click())
         Thread.sleep(1000)
         onView(withId(R.id.id_recycler_items_list))
             .check(RecyclerViewItemCountAssertion(availableItems.size + 1))
+        assert(FakeDatabaseItem.itemTypes.contains(testItem.itemType))
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/MoreFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/MoreFragmentTest.kt
@@ -13,7 +13,6 @@ import com.github.sdpteam15.polyevents.database.Database
 import com.github.sdpteam15.polyevents.fakedatabase.FakeDatabase
 import com.github.sdpteam15.polyevents.fakedatabase.FakeDatabaseItem
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -49,13 +48,13 @@ class MoreFragmentTest {
     @Test
     fun itemsAdminActivity() {
         var availableItems: MutableMap<Item, Int> = mutableMapOf()
-        availableItems[Item(null, "Chocolat", ItemType.OTHER)] = 30
-        availableItems[Item(null, "Kiwis", ItemType.OTHER)] = 10
-        availableItems[Item(null, "230V Plugs", ItemType.PLUG)] = 30
-        availableItems[Item(null, "Fridge (large)", ItemType.OTHER)] = 5
-        availableItems[Item(null, "Cord rewinder (15m)", ItemType.PLUG)] = 30
-        availableItems[Item(null, "Cord rewinder (50m)", ItemType.PLUG)] = 10
-        availableItems[Item(null, "Cord rewinder (25m)", ItemType.PLUG)] = 20
+        availableItems[Item(null, "Chocolat", "OTHER")] = 30
+        availableItems[Item(null, "Kiwis", "OTHER")] = 10
+        availableItems[Item(null, "230V Plugs", "PLUG")] = 30
+        availableItems[Item(null, "Fridge (large)", "OTHER")] = 5
+        availableItems[Item(null, "Cord rewinder (15m)", "PLUG")] = 30
+        availableItems[Item(null, "Cord rewinder (50m)", "PLUG")] = 10
+        availableItems[Item(null, "Cord rewinder (25m)", "PLUG")] = 20
 
         Database.currentDatabase = FakeDatabase
 

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/fakedatabase/FakeDatabaseItem.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/fakedatabase/FakeDatabaseItem.kt
@@ -12,6 +12,7 @@ object FakeDatabaseItem : ItemDatabaseInterface {
 
     init {
         initItems()
+        initItemTypes()
     }
 
     private fun initItems() {
@@ -95,6 +96,7 @@ object FakeDatabaseItem : ItemDatabaseInterface {
         itemTypeList: ObservableList<String>,
         userAccess: UserProfile?
     ): Observable<Boolean> {
+        itemTypeList.clear()
         itemTypeList.addAll(itemTypes)
         return Observable(true)
     }

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/fakedatabase/FakeDatabaseItem.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/fakedatabase/FakeDatabaseItem.kt
@@ -4,11 +4,11 @@ import com.github.sdpteam15.polyevents.database.objects.ItemDatabaseInterface
 import com.github.sdpteam15.polyevents.database.observe.Observable
 import com.github.sdpteam15.polyevents.database.observe.ObservableList
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import com.github.sdpteam15.polyevents.model.UserProfile
 
 object FakeDatabaseItem : ItemDatabaseInterface {
     lateinit var items: MutableMap<String, Pair<Item, Int>>
+    lateinit var itemTypes: MutableList<String>
 
     init {
         initItems()
@@ -16,19 +16,27 @@ object FakeDatabaseItem : ItemDatabaseInterface {
 
     private fun initItems() {
         items = mutableMapOf()
-        items["item1"] = Pair(Item("item1", "230V Plug", ItemType.PLUG), 20)
-        items["item2"] = Pair(Item("item2", "Cord rewinder (50m)", ItemType.PLUG), 10)
-        items["item3"] = Pair(Item("item3", "Microphone", ItemType.MICROPHONE), 1)
-        items["item4"] = Pair(Item("item4", "Cooking plate", ItemType.OTHER), 5)
-        items["item5"] = Pair(Item("item5", "Cord rewinder (100m)", ItemType.PLUG), 1)
-        items["item6"] = Pair(Item("item6", "Cord rewinder (10m)", ItemType.PLUG), 30)
-        items["item7"] = Pair(Item("item7", "Fridge(large)", ItemType.OTHER), 2)
+        items["item1"] = Pair(Item("item1", "230V Plug", "PLUG"), 20)
+        items["item2"] = Pair(Item("item2", "Cord rewinder (50m)", "PLUG"), 10)
+        items["item3"] = Pair(Item("item3", "Microphone", "MICROPHONE"), 1)
+        items["item4"] = Pair(Item("item4", "Cooking plate", "OTHER"), 5)
+        items["item5"] = Pair(Item("item5", "Cord rewinder (100m)", "PLUG"), 1)
+        items["item6"] = Pair(Item("item6", "Cord rewinder (10m)", "PLUG"), 30)
+        items["item7"] = Pair(Item("item7", "Fridge(large)", "OTHER"), 2)
+    }
+
+    private fun initItemTypes() {
+        itemTypes = mutableListOf(
+            "PLUG",
+            "MICROPHONE",
+            "OTHER"
+        )
     }
 
     override fun createItem(
         item: Item,
         count: Int,
-        profile: UserProfile?
+        userAccess: UserProfile?
     ): Observable<Boolean> {
         // generate random document ID like in firebase
         val itemId = FakeDatabase.generateRandomKey()
@@ -36,7 +44,7 @@ object FakeDatabaseItem : ItemDatabaseInterface {
         return Observable(b, this)
     }
 
-    override fun removeItem(itemId: String, profile: UserProfile?): Observable<Boolean> {
+    override fun removeItem(itemId: String, userAccess: UserProfile?): Observable<Boolean> {
         val b = items.remove(itemId) != null
         return Observable(b, this)
     }
@@ -44,7 +52,7 @@ object FakeDatabaseItem : ItemDatabaseInterface {
     override fun updateItem(
         item: Item,
         count: Int,
-        profile: UserProfile?
+        userAccess: UserProfile?
     ): Observable<Boolean> {
         // TODO should update add item if non existent in database ?
         // if (item.itemId == null) return createItem(item, count, profile)
@@ -54,7 +62,7 @@ object FakeDatabaseItem : ItemDatabaseInterface {
 
     override fun getItemsList(
         itemList: ObservableList<Pair<Item, Int>>,
-        profile: UserProfile?
+        userAccess: UserProfile?
     ): Observable<Boolean> {
         itemList.clear(this)
         for (item in items) {
@@ -65,7 +73,7 @@ object FakeDatabaseItem : ItemDatabaseInterface {
 
     override fun getAvailableItems(
         itemList: ObservableList<Pair<Item, Int>>,
-        profile: UserProfile?
+        userAccess: UserProfile?
     ): Observable<Boolean> {
         itemList.clear(this)
         val list = mutableListOf<Pair<Item, Int>>()
@@ -74,4 +82,22 @@ object FakeDatabaseItem : ItemDatabaseInterface {
         itemList.addAll(list, this)
         return Observable(true, this)
     }
+
+    override fun createItemType(
+        itemType: String,
+        userAccess: UserProfile?
+    ): Observable<Boolean> {
+        itemTypes.add(itemType)
+        return Observable(true, this)
+    }
+
+    override fun getItemTypes(
+        itemTypeList: ObservableList<String>,
+        userAccess: UserProfile?
+    ): Observable<Boolean> {
+        itemTypeList.addAll(itemTypes)
+        return Observable(true)
+    }
+
+
 }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/ItemsAdminActivity.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/ItemsAdminActivity.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.github.sdpteam15.polyevents.adapter.ItemAdapter
 import com.github.sdpteam15.polyevents.database.Database.currentDatabase
 import com.github.sdpteam15.polyevents.database.observe.ObservableList
+import com.github.sdpteam15.polyevents.helper.HelperFunctions
 import com.github.sdpteam15.polyevents.model.Item
 
 /**
@@ -38,7 +39,7 @@ class ItemsAdminActivity : AppCompatActivity() {
         }
         currentDatabase.itemDatabase!!.getItemTypes(itemTypes).observe(this) {
             if (!it.value)
-                println("query not satisfied")
+                HelperFunctions.showToast("Querry not satisfied", this)
         }
         items.observeRemove(this) {
             if (it.sender != currentDatabase.itemDatabase!!) {

--- a/app/src/main/java/com/github/sdpteam15/polyevents/ItemsAdminActivity.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/ItemsAdminActivity.kt
@@ -6,17 +6,13 @@ import android.transition.Slide
 import android.transition.TransitionManager
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.widget.EditText
-import android.widget.ImageButton
-import android.widget.LinearLayout
-import android.widget.PopupWindow
+import android.widget.*
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.github.sdpteam15.polyevents.adapter.ItemAdapter
 import com.github.sdpteam15.polyevents.database.Database.currentDatabase
 import com.github.sdpteam15.polyevents.database.observe.ObservableList
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 
 /**
  * Activity displaying Items and supports items creation and deletion
@@ -24,6 +20,7 @@ import com.github.sdpteam15.polyevents.model.ItemType
 class ItemsAdminActivity : AppCompatActivity() {
 
     private val items = ObservableList<Pair<Item, Int>>()
+    private val itemTypes = ObservableList<String>()
 
     /**
      * Recycler containing all the items
@@ -39,9 +36,14 @@ class ItemsAdminActivity : AppCompatActivity() {
             if (!it.value)
                 println("query not satisfied")
         }
+        currentDatabase.itemDatabase!!.getItemTypes(itemTypes).observe(this) {
+            if (!it.value)
+                println("query not satisfied")
+        }
         items.observeRemove(this) {
-            if (it.sender != currentDatabase.itemDatabase!!)
+            if (it.sender != currentDatabase.itemDatabase!!) {
                 currentDatabase.itemDatabase!!.removeItem(it.value.first.itemId!!)
+            }
         }
         items.observeAdd(this) {
             if (it.sender != currentDatabase.itemDatabase!!) {
@@ -51,6 +53,12 @@ class ItemsAdminActivity : AppCompatActivity() {
                             currentDatabase.itemDatabase!!.getItemsList(items)
                         }
                     }
+            }
+        }
+
+        itemTypes.observeAdd(this) {
+            if (it.sender != currentDatabase.itemDatabase!!) {
+                currentDatabase.itemDatabase!!.createItemType(it.value)
             }
         }
 
@@ -90,20 +98,35 @@ class ItemsAdminActivity : AppCompatActivity() {
         val itemName = view.findViewById<EditText>(R.id.id_edittext_item_name)
         val confirmButton = view.findViewById<ImageButton>(R.id.id_confirm_add_item_button)
         val itemQuantity = view.findViewById<EditText>(R.id.id_edittext_item_quantity)
+        val itemTypeTextView = view.findViewById<AutoCompleteTextView>(R.id.id_edittext_item_type)
+
+        //set adapter to show available item types
+        val adapter = ArrayAdapter(this, android.R.layout.select_dialog_item, itemTypes)
+        itemTypeTextView.setAdapter(adapter)
+
+        // update adapter when a new itemType is added
+        itemTypes.observe(this) { adapter.notifyDataSetChanged() }
 
         //set focus on the popup
         popupWindow.isFocusable = true
 
         // Set a click listener for popup's button widget
         confirmButton.setOnClickListener {
+            val itemType = itemTypeTextView.text.toString()
 
+            // add new item Type if not already present
+            if (itemType !in itemTypes) {
+                itemTypes.add(itemType)
+            }
 
+            // add new item
             items.add(
                 Pair(
-                    Item(null, itemName.text.toString(), ItemType.OTHER),
+                    Item(null, itemName.text.toString(), itemType),
                     itemQuantity.text.toString().toInt()
                 ), this
             )
+
             // Dismiss the popup window
             popupWindow.dismiss()
 

--- a/app/src/main/java/com/github/sdpteam15/polyevents/adapter/ItemAdapter.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/adapter/ItemAdapter.kt
@@ -31,8 +31,9 @@ class ItemAdapter(
      */
     inner class ItemViewHolder(view: View) : RecyclerView.ViewHolder(view) {
 
-        // TODO: Consider adding field for itemType
         private val itemName = view.findViewById<TextView>(R.id.id_list_item_name)
+        private val itemCount = view.findViewById<TextView>(R.id.id_list_item_count)
+        private val itemType = view.findViewById<TextView>(R.id.id_list_item_type)
         private val btnRemove = view.findViewById<ImageButton>(R.id.id_remove_item)
 
         /**
@@ -43,6 +44,8 @@ class ItemAdapter(
                 items.remove(item)
             }
             itemName.text = item.first.itemName
+            itemType.text = item.first.itemType
+            itemCount.text = item.second.toString()
         }
     }
 

--- a/app/src/main/java/com/github/sdpteam15/polyevents/database/DatabaseConstant.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/database/DatabaseConstant.kt
@@ -10,7 +10,8 @@ object DatabaseConstant {
         ITEM_COLLECTION("items"),
         EVENT_COLLECTION("events"),
         PROFILE_COLLECTION("profile"),
-        USER_COLLECTION("users");
+        USER_COLLECTION("users"),
+        ITEM_TYPE_COLLECTION("itemTypes");
         override fun toString(): String = value
     }
 

--- a/app/src/main/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestore.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestore.kt
@@ -1,7 +1,9 @@
 package com.github.sdpteam15.polyevents.database.objects
 
 import android.annotation.SuppressLint
+import com.github.sdpteam15.polyevents.database.DatabaseConstant
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_COLLECTION
+import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_TYPE_COLLECTION
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.ItemConstants.ITEM_COUNT
 import com.github.sdpteam15.polyevents.database.FirestoreDatabaseProvider
 import com.github.sdpteam15.polyevents.database.observe.Observable
@@ -79,4 +81,33 @@ object ItemDatabaseFirestore : ItemDatabaseInterface {
             itemList.addAll(items, this)
         }
     }
+
+    override fun createItemType(
+        itemType: String,
+        userAccess: UserProfile?
+    ): Observable<Boolean> = FirestoreDatabaseProvider.thenDoAdd(
+        FirestoreDatabaseProvider.firestore!!.collection(ITEM_TYPE_COLLECTION.value)
+            .add(
+                hashMapOf(
+                    DatabaseConstant.ItemConstants.ITEM_TYPE.value to itemType
+                )
+            )
+    )
+
+    override fun getItemTypes(
+        itemTypeList: ObservableList<String>,
+        userAccess: UserProfile?
+    ): Observable<Boolean> {
+        return FirestoreDatabaseProvider.thenDoGet(
+            FirestoreDatabaseProvider.firestore!!.collection(ITEM_TYPE_COLLECTION.value).get()
+        ) { querySnapshot ->
+            itemTypeList.clear(this)
+            val itemsTypes = querySnapshot.documents.map {
+                it.data!![DatabaseConstant.ItemConstants.ITEM_TYPE.value] as String
+            }
+            itemTypeList.addAll(itemsTypes, this)
+        }
+    }
+
+
 }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestore.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestore.kt
@@ -11,6 +11,7 @@ import com.github.sdpteam15.polyevents.database.observe.ObservableList
 import com.github.sdpteam15.polyevents.model.Item
 import com.github.sdpteam15.polyevents.model.UserProfile
 import com.github.sdpteam15.polyevents.util.ItemEntityAdapter
+import com.github.sdpteam15.polyevents.util.ItemTypeAdapter
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -85,14 +86,7 @@ object ItemDatabaseFirestore : ItemDatabaseInterface {
     override fun createItemType(
         itemType: String,
         userAccess: UserProfile?
-    ): Observable<Boolean> = FirestoreDatabaseProvider.thenDoAdd(
-        FirestoreDatabaseProvider.firestore!!.collection(ITEM_TYPE_COLLECTION.value)
-            .add(
-                hashMapOf(
-                    DatabaseConstant.ItemConstants.ITEM_TYPE.value to itemType
-                )
-            )
-    )
+    ): Observable<Boolean> = FirestoreDatabaseProvider.addEntity(itemType,ITEM_TYPE_COLLECTION,ItemTypeAdapter)
 
     override fun getItemTypes(
         itemTypeList: ObservableList<String>,
@@ -103,7 +97,7 @@ object ItemDatabaseFirestore : ItemDatabaseInterface {
         ) { querySnapshot ->
             itemTypeList.clear(this)
             val itemsTypes = querySnapshot.documents.map {
-                it.data!![DatabaseConstant.ItemConstants.ITEM_TYPE.value] as String
+                ItemTypeAdapter.fromDocument(it.data!!,it.id)
             }
             itemTypeList.addAll(itemsTypes, this)
         }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseInterface.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseInterface.kt
@@ -68,4 +68,25 @@ interface ItemDatabaseInterface {
         userAccess: UserProfile? = currentProfile
     ): Observable<Boolean>
 
+    /**
+     * create a new Item Type
+     * @param itemType item type we want to add in the database
+     * @param userAccess the user profile to use its permission
+     * @return An observer that will be set to true if the communication with the DB is over and no error
+     */
+    fun createItemType(
+        itemType: String,
+        userAccess: UserProfile? = currentProfile
+    ):Observable<Boolean>
+
+    /**
+     * Get list of existing items types
+     * @param itemTypeList the list of item types that will be set when the DB returns the information
+     * @param userAccess profile for database access
+     * @return An observer that will be set to true if the communication with the DB is over and no error
+     */
+    fun getItemTypes(
+        itemTypeList: ObservableList<String>,
+        userAccess: UserProfile? = currentProfile
+    ): Observable<Boolean>
 }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/model/Depot.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/model/Depot.kt
@@ -11,13 +11,13 @@ object Depot {
     const val DEPOT_NAME: String = "mainDepot"
 
     // TODO: consider storing the list of items instead of just the number
-    val inventory: MutableMap<ItemType, Int> = mutableMapOf()
+    val inventory: MutableMap<String, Int> = mutableMapOf()
 
     /**
      * Check if a certain item is available in the depot
      * @param itemType the item to check
      * @return true if the item's amount is bigger than 0
      */
-    fun isAvailable(itemType: ItemType): Boolean =
+    fun isAvailable(itemType: String): Boolean =
         inventory.getOrDefault(itemType, 0) > 0
 }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/model/Item.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/model/Item.kt
@@ -15,5 +15,5 @@ package com.github.sdpteam15.polyevents.model
 data class Item(
         val itemId: String?,
         val itemName: String,
-        val itemType: ItemType
+        val itemType: String
 )

--- a/app/src/main/java/com/github/sdpteam15/polyevents/model/ItemType.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/model/ItemType.kt
@@ -1,7 +1,0 @@
-package com.github.sdpteam15.polyevents.model
-
-// TODO: Add a different icon to each?
-enum class ItemType(val itemType: String) {
-    MICROPHONE("Microphone"), PLUG("Electric Plug"),
-    OTHER("Other")
-}

--- a/app/src/main/java/com/github/sdpteam15/polyevents/util/ItemEntityAdapter.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/util/ItemEntityAdapter.kt
@@ -2,7 +2,6 @@ package com.github.sdpteam15.polyevents.util
 
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.ItemConstants.*
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 
 object ItemEntityAdapter {
     fun toItemEntity(documentData: MutableMap<String, Any?>, id: String): Pair<Item, Int> =
@@ -10,16 +9,14 @@ object ItemEntityAdapter {
             Item(
                 id,
                 documentData[ITEM_NAME.value] as String,
-                ItemType.valueOf(
-                    documentData[ITEM_TYPE.value] as String
-                )
-            ), (documentData[ITEM_COUNT.value] as Long).toInt()
+                documentData[ITEM_TYPE.value] as String),
+                (documentData[ITEM_COUNT.value] as Long).toInt()
         )
 
     fun toItemDocument(item: Item, count: Int): HashMap<String, Any?> {
         val hash: HashMap<String, Any?> = hashMapOf(
             ITEM_NAME.value to item.itemName,
-            ITEM_TYPE.value to item.itemType.name,
+            ITEM_TYPE.value to item.itemType,
             ITEM_COUNT.value to count
         )
         if (item.itemId != null) {

--- a/app/src/main/java/com/github/sdpteam15/polyevents/util/ItemTypeAdapter.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/util/ItemTypeAdapter.kt
@@ -1,0 +1,12 @@
+package com.github.sdpteam15.polyevents.util
+
+import com.github.sdpteam15.polyevents.database.DatabaseConstant.ItemConstants.ITEM_TYPE
+
+object ItemTypeAdapter : AdapterInterface<String> {
+    override fun toDocument(element: String): HashMap<String, Any?> =
+        hashMapOf(ITEM_TYPE.value to element)
+
+    override fun fromDocument(document: MutableMap<String, Any?>, id: String): String =
+        document[ITEM_TYPE.value] as String
+
+}

--- a/app/src/main/res/layout/popup_add_item.xml
+++ b/app/src/main/res/layout/popup_add_item.xml
@@ -67,15 +67,13 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/id_edittext_item_name" />
 
-            <Spinner
-                android:id="@+id/id_spinner_item_type"
-                android:layout_width="wrap_content"
+            <AutoCompleteTextView
+                android:id="@+id/id_edittext_item_type"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="@+id/id_edittext_item_quantity"
                 app:layout_constraintStart_toStartOf="@+id/id_edittext_item_quantity"
-                app:layout_constraintTop_toBottomOf="@+id/id_edittext_item_quantity"
-                app:layout_constraintVertical_bias="0.0" />
+                app:layout_constraintTop_toBottomOf="@+id/id_edittext_item_quantity" />
 
 
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/popup_add_item.xml
+++ b/app/src/main/res/layout/popup_add_item.xml
@@ -71,6 +71,7 @@
                 android:id="@+id/id_edittext_item_type"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:hint="Item type"
                 app:layout_constraintEnd_toEndOf="@+id/id_edittext_item_quantity"
                 app:layout_constraintStart_toStartOf="@+id/id_edittext_item_quantity"
                 app:layout_constraintTop_toBottomOf="@+id/id_edittext_item_quantity" />

--- a/app/src/main/res/layout/tab_material_item.xml
+++ b/app/src/main/res/layout/tab_material_item.xml
@@ -20,6 +20,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -33,18 +34,40 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="1.0"
                 app:srcCompat="@android:drawable/ic_delete" />
+
+            <TextView
+                android:id="@+id/id_list_item_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/id_remove_item"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/id_list_item_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
-                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/id_remove_item"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/id_list_item_type"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/id_remove_item"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/id_list_item_name"
+                app:layout_constraintVertical_bias="1.0" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.cardview.widget.CardView>

--- a/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
@@ -1,8 +1,8 @@
 package com.github.sdpteam15.polyevents.database.objects
 
-import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_TYPE_COLLECTION
 import com.github.sdpteam15.polyevents.database.DatabaseConstant
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_COLLECTION
+import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_TYPE_COLLECTION
 import com.github.sdpteam15.polyevents.database.DatabaseInterface
 import com.github.sdpteam15.polyevents.database.FirestoreDatabaseProvider
 import com.github.sdpteam15.polyevents.database.observe.ObservableList
@@ -15,7 +15,10 @@ import com.github.sdpteam15.polyevents.model.UserProfile
 import com.github.sdpteam15.polyevents.util.ItemEntityAdapter
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
-import com.google.firebase.firestore.*
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -57,15 +60,16 @@ class ItemDatabaseFirestoreTest {
     }
 
     @Test
-    fun variableCorrectlySet(){
-        val mockedUserLogin = Mockito.mock(UserLoginInterface::class.java) as UserLoginInterface<AuthResult>
+    fun variableCorrectlySet() {
+        val mockedUserLogin =
+            Mockito.mock(UserLoginInterface::class.java) as UserLoginInterface<AuthResult>
         UserLogin.currentUserLogin = mockedUserLogin
         FirestoreDatabaseProvider.currentUser = user
         Mockito.`when`(mockedUserLogin.isConnected()).thenReturn(true)
         FirestoreDatabaseProvider.currentProfile = UserProfile()
-        assert(ItemDatabaseFirestore.currentUser==FirestoreDatabaseProvider.currentUser)
-        assert(ItemDatabaseFirestore.currentProfile==FirestoreDatabaseProvider.currentProfile)
-        assert(ItemDatabaseFirestore.firestore==mockedDatabase)
+        assert(ItemDatabaseFirestore.currentUser == FirestoreDatabaseProvider.currentUser)
+        assert(ItemDatabaseFirestore.currentProfile == FirestoreDatabaseProvider.currentProfile)
+        assert(ItemDatabaseFirestore.firestore == mockedDatabase)
     }
 
     @After
@@ -215,9 +219,9 @@ class ItemDatabaseFirestoreTest {
         val taskReferenceMock = mock(Task::class.java) as Task<QuerySnapshot>
         val mockedQuerySnapshot = mock(QuerySnapshot::class.java) as QuerySnapshot
 
-        val testItems = ObservableList<Pair<Item,Int>>()
+        val testItems = ObservableList<Pair<Item, Int>>()
 
-        val itemToBeAdded = mutableListOf<Pair<Item,Int>>()
+        val itemToBeAdded = mutableListOf<Pair<Item, Int>>()
         itemToBeAdded.add(Pair(Item("item1", "230V Plug", "PLUG"), 20))
         itemToBeAdded.add(Pair(Item("item2", "Cord rewinder (50m)", "PLUG"), 10))
         itemToBeAdded.add(Pair(Item("item3", "Microphone", "MICROPHONE"), 1))
@@ -244,10 +248,58 @@ class ItemDatabaseFirestoreTest {
 
         val result = FirestoreDatabaseProvider.itemDatabase!!.getItemsList(testItems)
         assert(result.value!!)
-        for (itemType in itemToBeAdded){
+        for (itemType in itemToBeAdded) {
             assert(itemType in testItems)
         }
     }
+
+    @Test
+    fun getAvailableItemsWorks() {
+        val mockedCollectionReference = mock(CollectionReference::class.java)
+        val mockedCollectionReferenceFiltered = mock(CollectionReference::class.java)
+        val taskReferenceMock = mock(Task::class.java) as Task<QuerySnapshot>
+        val mockedQuerySnapshot = mock(QuerySnapshot::class.java) as QuerySnapshot
+
+        val testItems = ObservableList<Pair<Item, Int>>()
+
+        val itemToBeAdded = mutableListOf<Pair<Item, Int>>()
+        itemToBeAdded.add(Pair(Item("item1", "230V Plug", "PLUG"), 20))
+        itemToBeAdded.add(Pair(Item("item2", "Cord rewinder (50m)", "PLUG"), 10))
+        itemToBeAdded.add(Pair(Item("item3", "Microphone", "MICROPHONE"), 1))
+        itemToBeAdded.add(Pair(Item("item4", "Cooking plate", "OTHER"), 5))
+        itemToBeAdded.add(Pair(Item("item5", "Cord rewinder (100m)", "PLUG"), 1))
+        itemToBeAdded.add(Pair(Item("item6", "Cord rewinder (10m)", "PLUG"), 30))
+        itemToBeAdded.add(Pair(Item("item7", "Fridge(large)", "OTHER"), 2))
+
+
+        When(mockedDatabase.collection(ITEM_COLLECTION.value)).thenReturn(mockedCollectionReference)
+        When(
+            mockedCollectionReference.whereGreaterThan(
+                DatabaseConstant.ItemConstants.ITEM_COUNT.value,
+                0
+            )
+        ).thenReturn(mockedCollectionReferenceFiltered)
+        When(mockedCollectionReferenceFiltered.get()).thenReturn(
+            taskReferenceMock
+        )
+
+        When(taskReferenceMock.addOnSuccessListener(any())).thenAnswer {
+            FirestoreDatabaseProvider.lastQuerySuccessListener!!.onSuccess(mockedQuerySnapshot)
+            //set method in hard to see if the success listener is successfully called
+            testItems.addAll(itemToBeAdded)
+            taskReferenceMock
+        }
+        When(taskReferenceMock.addOnFailureListener(any())).thenAnswer {
+            taskReferenceMock
+        }
+
+        val result = FirestoreDatabaseProvider.itemDatabase!!.getAvailableItems(testItems)
+        assert(result.value!!)
+        for (itemType in itemToBeAdded) {
+            assert(itemType in testItems)
+        }
+    }
+
 
     @Test
     fun addItemTypeInDatabaseWorks() {
@@ -256,7 +308,9 @@ class ItemDatabaseFirestoreTest {
 
         val testItemType = "TEST_ITEM_TYPE"
 
-        When(mockedDatabase.collection(ITEM_TYPE_COLLECTION.value)).thenReturn(mockedCollectionReference)
+        When(mockedDatabase.collection(ITEM_TYPE_COLLECTION.value)).thenReturn(
+            mockedCollectionReference
+        )
         When(
             mockedCollectionReference.add(
                 hashMapOf(
@@ -290,10 +344,12 @@ class ItemDatabaseFirestoreTest {
         val taskReferenceMock = mock(Task::class.java) as Task<QuerySnapshot>
         val mockedQuerySnapshot = mock(QuerySnapshot::class.java) as QuerySnapshot
 
-        val itemTypesToBeAdded = mutableListOf("Plug","Microphone","Wire","Fridge")
+        val itemTypesToBeAdded = mutableListOf("Plug", "Microphone", "Wire", "Fridge")
         val testItemType = ObservableList<String>()
 
-        When(mockedDatabase.collection(ITEM_TYPE_COLLECTION.value)).thenReturn(mockedCollectionReference)
+        When(mockedDatabase.collection(ITEM_TYPE_COLLECTION.value)).thenReturn(
+            mockedCollectionReference
+        )
         When(mockedCollectionReference.get()).thenReturn(
             taskReferenceMock
         )
@@ -310,7 +366,7 @@ class ItemDatabaseFirestoreTest {
 
         val result = FirestoreDatabaseProvider.itemDatabase!!.getItemTypes(testItemType)
         assert(result.value!!)
-        for (itemType in itemTypesToBeAdded){
+        for (itemType in itemTypesToBeAdded) {
             assert(itemType in testItemType)
         }
     }

--- a/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
@@ -7,7 +7,6 @@ import com.github.sdpteam15.polyevents.login.GoogleUserLogin
 import com.github.sdpteam15.polyevents.login.UserLogin
 import com.github.sdpteam15.polyevents.login.UserLoginInterface
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import com.github.sdpteam15.polyevents.model.UserEntity
 import com.github.sdpteam15.polyevents.model.UserProfile
 import com.github.sdpteam15.polyevents.util.ItemEntityAdapter
@@ -81,7 +80,7 @@ class ItemDatabaseFirestoreTest {
         val mockedCollectionReference = mock(CollectionReference::class.java)
         val taskReferenceMock = mock(Task::class.java) as Task<DocumentReference>
 
-        val testItem = Item("xxxbananaxxx", "banana", ItemType.OTHER)
+        val testItem = Item("xxxbananaxxx", "banana", "OTHER")
         val testQuantity = 3
 
         When(mockedDatabase.collection(ITEM_COLLECTION.value)).thenReturn(mockedCollectionReference)
@@ -97,7 +96,7 @@ class ItemDatabaseFirestoreTest {
         )
 
         var itemNameAdded = ""
-        var itemTypeAdded: ItemType? = null
+        var itemTypeAdded: String? = null
         var itemCountAdded = 0
         var itemIdAdded = ""
 
@@ -129,7 +128,7 @@ class ItemDatabaseFirestoreTest {
         val documentReference = mock(DocumentReference::class.java) as DocumentReference
         val taskMock = mock(Task::class.java) as Task<Void>
 
-        val testItem = Item("xxxbananaxxx", "banana", ItemType.OTHER)
+        val testItem = Item("xxxbananaxxx", "banana", "OTHER")
         val testQuantity = 3
 
         When(mockedDatabase.collection(ITEM_COLLECTION.value)).thenReturn(mockedCollectionReference)
@@ -144,7 +143,7 @@ class ItemDatabaseFirestoreTest {
         ).thenReturn(taskMock)
 
         var itemNameUpdated = ""
-        var itemTypeUpdated: ItemType? = null
+        var itemTypeUpdated: String? = null
         var itemCountUpdated = 0
         var itemIdUpdated = ""
 
@@ -176,7 +175,7 @@ class ItemDatabaseFirestoreTest {
         val documentReference = mock(DocumentReference::class.java) as DocumentReference
         val taskMock = mock(Task::class.java) as Task<Void>
 
-        val testItem = Item("xxxbananaxxx", "banana", ItemType.OTHER)
+        val testItem = Item("xxxbananaxxx", "banana", "OTHER")
         val testQuantity = 3
 
         When(mockedDatabase.collection(ITEM_COLLECTION.value)).thenReturn(mockedCollectionReference)
@@ -184,7 +183,7 @@ class ItemDatabaseFirestoreTest {
         When(documentReference.delete()).thenReturn(taskMock)
 
         var itemNameAdded = ""
-        var itemTypeAdded: ItemType? = null
+        var itemTypeAdded: String? = null
         var itemCountAdded = 0
         var itemIdAdded = ""
 

--- a/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
@@ -5,6 +5,7 @@ import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConst
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_TYPE_COLLECTION
 import com.github.sdpteam15.polyevents.database.DatabaseInterface
 import com.github.sdpteam15.polyevents.database.FirestoreDatabaseProvider
+import com.github.sdpteam15.polyevents.database.FirestoreDatabaseProviderTest
 import com.github.sdpteam15.polyevents.database.observe.ObservableList
 import com.github.sdpteam15.polyevents.login.GoogleUserLogin
 import com.github.sdpteam15.polyevents.login.UserLogin
@@ -13,6 +14,7 @@ import com.github.sdpteam15.polyevents.model.Item
 import com.github.sdpteam15.polyevents.model.UserEntity
 import com.github.sdpteam15.polyevents.model.UserProfile
 import com.github.sdpteam15.polyevents.util.ItemEntityAdapter
+import com.github.sdpteam15.polyevents.util.ItemTypeAdapter
 import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.firestore.CollectionReference
@@ -104,7 +106,6 @@ class ItemDatabaseFirestoreTest {
         var itemTypeAdded: String? = null
         var itemCountAdded = 0
         var itemIdAdded = ""
-
         When(taskReferenceMock.addOnSuccessListener(any())).thenAnswer {
             FirestoreDatabaseProvider.lastAddSuccessListener!!.onSuccess(null)
             //set method in hard to see if the success listener is successfully called
@@ -305,7 +306,7 @@ class ItemDatabaseFirestoreTest {
     fun addItemTypeInDatabaseWorks() {
         val mockedCollectionReference = mock(CollectionReference::class.java)
         val taskReferenceMock = mock(Task::class.java) as Task<DocumentReference>
-
+        val docReferenceMock = mock(DocumentReference::class.java) as DocumentReference
         val testItemType = "TEST_ITEM_TYPE"
 
         When(mockedDatabase.collection(ITEM_TYPE_COLLECTION.value)).thenReturn(
@@ -313,18 +314,16 @@ class ItemDatabaseFirestoreTest {
         )
         When(
             mockedCollectionReference.add(
-                hashMapOf(
-                    DatabaseConstant.ItemConstants.ITEM_TYPE.value to testItemType
-                )
+                ItemTypeAdapter.toDocument(testItemType)
             )
         ).thenReturn(
             taskReferenceMock
         )
+        When(docReferenceMock.id).thenReturn("test")
 
         var itemTypeAdded: String? = null
-
         When(taskReferenceMock.addOnSuccessListener(any())).thenAnswer {
-            FirestoreDatabaseProvider.lastAddSuccessListener!!.onSuccess(null)
+            FirestoreDatabaseProvider.lastAddSuccessListener!!.onSuccess(docReferenceMock)
             //set method in hard to see if the success listener is successfully called
             itemTypeAdded = testItemType
             taskReferenceMock

--- a/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/database/objects/ItemDatabaseFirestoreTest.kt
@@ -1,5 +1,7 @@
 package com.github.sdpteam15.polyevents.database.objects
 
+import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_TYPE_COLLECTION
+import com.github.sdpteam15.polyevents.database.DatabaseConstant
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.CollectionConstant.ITEM_COLLECTION
 import com.github.sdpteam15.polyevents.database.DatabaseInterface
 import com.github.sdpteam15.polyevents.database.FirestoreDatabaseProvider
@@ -207,4 +209,41 @@ class ItemDatabaseFirestoreTest {
         assert(itemCountAdded == testQuantity)
         assert(itemIdAdded == testItem.itemId!!)
     }
+
+    @Test
+    fun addItemTypeInDatabaseWorks() {
+        val mockedCollectionReference = mock(CollectionReference::class.java)
+        val taskReferenceMock = mock(Task::class.java) as Task<DocumentReference>
+
+        val testItemType = "TEST_ITEM_TYPE"
+
+        When(mockedDatabase.collection(ITEM_TYPE_COLLECTION.value)).thenReturn(mockedCollectionReference)
+        When(
+            mockedCollectionReference.add(
+                hashMapOf(
+                    DatabaseConstant.ItemConstants.ITEM_TYPE.value to testItemType
+                )
+            )
+        ).thenReturn(
+            taskReferenceMock
+        )
+
+        var itemTypeAdded: String? = null
+
+        When(taskReferenceMock.addOnSuccessListener(any())).thenAnswer {
+            FirestoreDatabaseProvider.lastAddSuccessListener!!.onSuccess(null)
+            //set method in hard to see if the success listener is successfully called
+            itemTypeAdded = testItemType
+            taskReferenceMock
+        }
+        When(taskReferenceMock.addOnFailureListener(any())).thenAnswer {
+            taskReferenceMock
+        }
+
+        val result = FirestoreDatabaseProvider.itemDatabase!!.createItemType(testItemType)
+        assert(result.value!!)
+        assert(itemTypeAdded == testItemType)
+    }
+
+    @
 }

--- a/app/src/test/java/com/github/sdpteam15/polyevents/model/DepotTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/model/DepotTest.kt
@@ -9,11 +9,11 @@ class DepotTest {
 
     @Test
     fun testItemAvailabilityInDepot() {
-        depot.inventory[ItemType.PLUG] = 1
-        assertTrue(depot.isAvailable(ItemType.PLUG))
+        depot.inventory["PLUG"] = 1
+        assertTrue(depot.isAvailable("PLUG"))
 
-        depot.inventory[ItemType.PLUG] = 0
-        assertFalse(depot.isAvailable(ItemType.PLUG))
+        depot.inventory["PLUG"] = 0
+        assertFalse(depot.isAvailable("PLUG"))
     }
 
 }

--- a/app/src/test/java/com/github/sdpteam15/polyevents/model/EventTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/model/EventTest.kt
@@ -71,14 +71,14 @@ class EventTest {
 
     @Test
     fun testAddItemToEventInventory() {
-        val item = Item(null, "micro1", ItemType.MICROPHONE)
+        val item = Item(null, "micro1", "MICROPHONE")
         event.addItem(item)
         assertTrue(event.hasItem(item))
     }
 
     @Test
     fun testAddRemoveItem() {
-        val item = Item(null, "micro1", ItemType.MICROPHONE)
+        val item = Item(null, "micro1", "MICROPHONE")
         event.addItem(item)
         event.removeItem(item)
         assertFalse(event.hasItem(item))
@@ -87,7 +87,7 @@ class EventTest {
     @Test
     fun testRemoveItemBasedOnItemEquality() {
         val itemId = "micro1"
-        val itemType = ItemType.MICROPHONE
+        val itemType = "MICROPHONE"
         val item = Item(null, itemId, itemType)
         event.addItem(item)
 

--- a/app/src/test/java/com/github/sdpteam15/polyevents/model/ItemTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/model/ItemTest.kt
@@ -8,7 +8,7 @@ class ItemTest {
     lateinit var testItem: Item
 
     val itemName = "micro1"
-    val itemType = ItemType.MICROPHONE
+    val itemType = "MICROPHONE"
 
     @Before
     fun setup() {

--- a/app/src/test/java/com/github/sdpteam15/polyevents/util/EventAdapterTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/util/EventAdapterTest.kt
@@ -4,7 +4,6 @@ package com.github.sdpteam15.polyevents.util
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.EventConstant.*
 import com.github.sdpteam15.polyevents.model.Event
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -24,8 +23,8 @@ class EventAdapterTest {
     val tag1 = "GOOD"
     val tag2 = "BAD"
 
-    val item1 = Item(null, "micro1", ItemType.MICROPHONE)
-    val item2 = Item(null, "plug2", ItemType.PLUG)
+    val item1 = Item(null, "micro1", "MICROPHONE")
+    val item2 = Item(null, "plug2", "PLUG")
 
     lateinit var event: Event
 

--- a/app/src/test/java/com/github/sdpteam15/polyevents/util/ItemEntityAdapterTest.kt
+++ b/app/src/test/java/com/github/sdpteam15/polyevents/util/ItemEntityAdapterTest.kt
@@ -2,7 +2,6 @@ package com.github.sdpteam15.polyevents.util
 
 import com.github.sdpteam15.polyevents.database.DatabaseConstant.ItemConstants.*
 import com.github.sdpteam15.polyevents.model.Item
-import com.github.sdpteam15.polyevents.model.ItemType
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -10,7 +9,7 @@ import org.junit.Test
 class ItemEntityAdapterTest {
     val itemId = "micro1"
     val itemName = "Microphone Elgato"
-    val itemType = ItemType.MICROPHONE
+    val itemType = "MICROPHONE"
     val itemQuantity = 5
 
     lateinit var itemEntity: Item
@@ -32,7 +31,7 @@ class ItemEntityAdapterTest {
         val itemDocumentData: HashMap<String, Any?> = hashMapOf(
             ITEM_NAME.value to itemName,
             ITEM_DOCUMENT_ID.value to itemId,
-            ITEM_TYPE.value to itemType.name,
+            ITEM_TYPE.value to itemType,
             ITEM_COUNT.value to itemQuantity.toLong()
         )
         val obtainedItem = ItemEntityAdapter.toItemEntity(itemDocumentData, itemId)
@@ -43,11 +42,7 @@ class ItemEntityAdapterTest {
 
     @Test
     fun conversionOfItemEntityToDocumentPreservesData() {
-        assertEquals(
-            ItemType.valueOf(
-                document[ITEM_TYPE.value] as String
-            ), itemEntity.itemType
-        )
+        assertEquals(document[ITEM_TYPE.value] as String, itemEntity.itemType)
         assertEquals(document[ITEM_DOCUMENT_ID.value], itemEntity.itemId)
         assertEquals(document[ITEM_COUNT.value], itemQuantity)
         assertEquals(document[ITEM_NAME.value], itemName)
@@ -62,11 +57,7 @@ class ItemEntityAdapterTest {
         )
         document = ItemEntityAdapter.toItemDocument(itemEntity2, itemQuantity)
 
-        assertEquals(
-            ItemType.valueOf(
-                document[ITEM_TYPE.value] as String
-            ), itemEntity.itemType
-        )
+        assertEquals(document[ITEM_TYPE.value] as String, itemEntity.itemType)
         assertEquals(document[ITEM_COUNT.value], itemQuantity)
         assertEquals(document[ITEM_NAME.value], itemName)
         assert(!document.containsKey(ITEM_DOCUMENT_ID.value))


### PR DESCRIPTION
Hello,

This pull request features the new way we use Items types. It allows users to create a new type when creating an item.
Item types are just strings stored on firestore under the "itemType" collection
There is no feature to delete item types after they are created and we will discuss about it maybe later.

Feel free to comment my pull request, it should not be too complicated to read.