### PR TITLE
Fb steph bug fixes 2

### DIFF
--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/activity/EventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/activity/EventActivityTest.kt
@@ -44,10 +44,7 @@ import org.mockito.Mockito.mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.anyOrNull
 import java.time.LocalDateTime
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
+import kotlin.test.*
 import org.mockito.Mockito.`when` as When
 
 
@@ -72,6 +69,8 @@ class EventActivityTest {
 
     private lateinit var localDatabase: LocalDatabase
     private lateinit var mockedNotificationsScheduler: NotificationsScheduler
+
+    private var notificationId: Int = 0
 
     @Before
     @Suppress("UNCHECKED_CAST")
@@ -158,13 +157,19 @@ class EventActivityTest {
         mockedNotificationsScheduler = mock(NotificationsScheduler::class.java)
         When(mockedNotificationsScheduler.cancelNotification(anyOrNull())).then { }
         When(mockedNotificationsScheduler.generateNewNotificationId()).thenReturn(0)
+
+        notificationId = 0
         When(
             mockedNotificationsScheduler.scheduleEventNotification(
                 eventId = anyOrNull(),
                 notificationMessage = anyOrNull(),
                 scheduledTime = anyOrNull()
             )
-        ).thenReturn(0)
+        ).then {
+            val temp = notificationId
+            notificationId += 1
+            temp
+        }
 
         // Create local db
         val context: Context = ApplicationProvider.getApplicationContext()
@@ -809,5 +814,80 @@ class EventActivityTest {
             eventBeforeNotificationId = null
         )
         assertEquals(eventLocalWithCommonAttributes, EventLocal.fromEvent(event))
+    }
+
+    @Test
+    fun testNotificationsNotScheduledIfEventAlreadyEnded() {
+        goToEventActivityWithIntent(publicEventId)
+
+        val currentTime = LocalDateTime.of(2021, 6, 3, 22, 30, 0)
+        val eventStartTime = LocalDateTime.of(2021, 6, 3, 18, 0, 0)
+        val eventEndTime = LocalDateTime.of(2021, 6, 3, 20, 0, 0)
+
+        val testEvent = testPublicEvent.copy(
+            startTime = eventStartTime,
+            endTime = eventEndTime
+        )
+
+        val (notificationBeforeId, notificationStartId) =
+            EventActivity.scheduleNotificationWithRespectToCurrentTime(
+                event = testEvent,
+                currentTime = currentTime,
+                startTimeNotificationMessage = "",
+                beforeEventNotificationMessage = ""
+            )
+
+        assertNull(notificationBeforeId)
+        assertNull(notificationStartId)
+    }
+
+    @Test
+    fun testOnlyOneNotificationAtEventStartIfAlreadyStarted() {
+        goToEventActivityWithIntent(publicEventId)
+
+        val currentTime = LocalDateTime.of(2021, 6, 3, 22, 30, 0)
+        val eventStartTime = LocalDateTime.of(2021, 6, 3, 18, 0, 0)
+        val eventEndTime = LocalDateTime.of(2021, 6, 3, 23, 0, 0)
+
+        val testEvent = testPublicEvent.copy(
+            startTime = eventStartTime,
+            endTime = eventEndTime
+        )
+
+        val (notificationBeforeId, notificationStartId) =
+            EventActivity.scheduleNotificationWithRespectToCurrentTime(
+                event = testEvent,
+                currentTime = currentTime,
+                startTimeNotificationMessage = "",
+                beforeEventNotificationMessage = ""
+            )
+
+        assertNull(notificationBeforeId)
+        assertNotNull(notificationStartId)
+    }
+
+    @Test
+    fun testNotificationsScheduledIfEventHasNotStarted() {
+        goToEventActivityWithIntent(publicEventId)
+
+        val currentTime = LocalDateTime.of(2021, 6, 3, 6, 30, 0)
+        val eventStartTime = LocalDateTime.of(2021, 6, 3, 18, 0, 0)
+        val eventEndTime = LocalDateTime.of(2021, 6, 3, 20, 0, 0)
+
+        val testEvent = testPublicEvent.copy(
+            startTime = eventStartTime,
+            endTime = eventEndTime
+        )
+
+        val (notificationBeforeId, notificationStartId) =
+            EventActivity.scheduleNotificationWithRespectToCurrentTime(
+                event = testEvent,
+                currentTime = currentTime,
+                startTimeNotificationMessage = "",
+                beforeEventNotificationMessage = ""
+            )
+
+        assertNotNull(notificationBeforeId)
+        assertNotNull(notificationStartId)
     }
 }

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/activity/EventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/activity/EventActivityTest.kt
@@ -98,6 +98,7 @@ class EventActivityTest {
             eventName = "limited Event only",
             description = "Super noisy activity !",
             startTime = LocalDateTime.of(2021, 3, 7, 21, 15),
+            endTime = LocalDateTime.of(2021, 3, 7, 23, 50, 0),
             organizer = "AcademiC DeCibel",
             zoneName = "Concert Hall",
             tags = mutableListOf("music", "live", "pogo")

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/activity/EventActivityTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/activity/EventActivityTest.kt
@@ -777,49 +777,6 @@ class EventActivityTest {
         assert(retrievedEventsAfterUnfollow.isEmpty())
     }
 
-    /**
-     * Idea taken from StackOverflow
-     * https://stackoverflow.com/questions/25209508/how-to-set-a-specific-rating-on-ratingbar-in-espresso/25226081
-     */
-    class SetRating(val newRating: Float) : ViewAction {
-        override fun getConstraints(): Matcher<View> {
-            return isAssignableFrom(RatingBar::class.java)
-        }
-
-        override fun getDescription(): String {
-            return "Custom view action to set rating."
-        }
-
-        override fun perform(uiController: UiController?, view: View) {
-            val ratingBar = view as RatingBar
-            ratingBar.rating = newRating
-        }
-    }
-
-    private fun goToEventActivityWithIntent(eventId: String) {
-        val intent = Intent(
-            ApplicationProvider.getApplicationContext(),
-            EventActivity::class.java
-        ).apply {
-            putExtra(EXTRA_EVENT_ID, eventId)
-        }
-
-        scenario = ActivityScenario.launch(intent)
-
-        EventActivity.database = localDatabase
-        EventActivity.notificationsScheduler = mockedNotificationsScheduler
-
-        Thread.sleep(1000)
-    }
-
-    private fun testEventLocalEqualsEventEntity(eventLocal: EventLocal, event: Event) {
-        val eventLocalWithCommonAttributes = eventLocal.copy(
-            eventStartNotificationId = null,
-            eventBeforeNotificationId = null
-        )
-        assertEquals(eventLocalWithCommonAttributes, EventLocal.fromEvent(event))
-    }
-
     @Test
     fun testNotificationsNotScheduledIfEventAlreadyEnded() {
         goToEventActivityWithIntent(publicEventId)
@@ -893,5 +850,48 @@ class EventActivityTest {
 
         assertNotNull(notificationBeforeId)
         assertNotNull(notificationStartId)
+    }
+
+    /**
+     * Idea taken from StackOverflow
+     * https://stackoverflow.com/questions/25209508/how-to-set-a-specific-rating-on-ratingbar-in-espresso/25226081
+     */
+    class SetRating(val newRating: Float) : ViewAction {
+        override fun getConstraints(): Matcher<View> {
+            return isAssignableFrom(RatingBar::class.java)
+        }
+
+        override fun getDescription(): String {
+            return "Custom view action to set rating."
+        }
+
+        override fun perform(uiController: UiController?, view: View) {
+            val ratingBar = view as RatingBar
+            ratingBar.rating = newRating
+        }
+    }
+
+    private fun goToEventActivityWithIntent(eventId: String) {
+        val intent = Intent(
+            ApplicationProvider.getApplicationContext(),
+            EventActivity::class.java
+        ).apply {
+            putExtra(EXTRA_EVENT_ID, eventId)
+        }
+
+        scenario = ActivityScenario.launch(intent)
+
+        EventActivity.database = localDatabase
+        EventActivity.notificationsScheduler = mockedNotificationsScheduler
+
+        Thread.sleep(1000)
+    }
+
+    private fun testEventLocalEqualsEventEntity(eventLocal: EventLocal, event: Event) {
+        val eventLocalWithCommonAttributes = eventLocal.copy(
+            eventStartNotificationId = null,
+            eventBeforeNotificationId = null
+        )
+        assertEquals(eventLocalWithCommonAttributes, EventLocal.fromEvent(event))
     }
 }

--- a/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/fragments/EventListFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/sdpteam15/polyevents/view/fragments/EventListFragmentTest.kt
@@ -63,8 +63,8 @@ class EventListFragmentTest {
             eventId = "1",
             eventName = firstEventName,
             description = "Super hungry activity !",
-            startTime = LocalDateTime.of(2021, 3, 7, 12, 15),
-            endTime = LocalDateTime.of(2021, 3, 7, 13, 0, 0),
+            startTime = LocalDateTime.of(2022, 3, 7, 12, 15),
+            endTime = LocalDateTime.of(2022, 3, 7, 13, 0, 0),
             organizer = "The fish band",
             zoneName = "Kitchen",
             tags = mutableListOf("sushi", "japan", "cooking")
@@ -84,7 +84,8 @@ class EventListFragmentTest {
             description = "Super cool activity !" +
                     " With a super long description that essentially describes and explains" +
                     " the content of the activity we are speaking of.",
-            startTime = LocalDateTime.of(2021, 3, 7, 14, 15),
+            startTime = LocalDateTime.of(2022, 3, 7, 14, 15),
+            endTime = LocalDateTime.of(2022, 3, 8, 13, 0, 0),
             organizer = "The Aqua Poney team",
             zoneName = "Swimming pool"
         )
@@ -94,7 +95,8 @@ class EventListFragmentTest {
             eventId = "3",
             eventName = "Concert",
             description = "Super noisy activity !",
-            startTime = LocalDateTime.of(2021, 3, 7, 21, 15),
+            startTime = LocalDateTime.of(2022, 3, 7, 21, 15),
+            endTime = LocalDateTime.of(2022, 3, 8, 23, 0, 0),
             organizer = "AcademiC DeCibel",
             zoneName = "Concert Hall",
             tags = mutableListOf("music", "live", "pogo")
@@ -187,6 +189,7 @@ class EventListFragmentTest {
         assertChecked(R.id.event_list_my_events_switch)
 
         // My events updated
+        Thread.sleep(2000)
         assertRecyclerViewItemCount(R.id.recycler_events_list, 2)
     }
 

--- a/app/src/main/java/com/github/sdpteam15/polyevents/helper/NotificationsHelper.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/helper/NotificationsHelper.kt
@@ -189,7 +189,7 @@ fun NotificationManager.sendEventNotification(
     val builder = NotificationCompat.Builder(
         applicationContext,
         applicationContext.getString(R.string.notification_channel_id)
-    ).setSmallIcon(R.drawable.ic_event)        // TODO: replace with application icon
+    ).setSmallIcon(R.drawable.ic_ico)
         .setContentTitle(applicationContext.getString(R.string.app_name))
         .setContentText(messageBody)
         .setContentIntent(contentPendingIntent)

--- a/app/src/main/java/com/github/sdpteam15/polyevents/view/activity/EventActivity.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/view/activity/EventActivity.kt
@@ -32,8 +32,8 @@ import com.github.sdpteam15.polyevents.view.fragments.LeaveEventReviewFragment
 import com.github.sdpteam15.polyevents.view.fragments.ProgressDialogFragment
 import com.github.sdpteam15.polyevents.viewmodel.EventLocalViewModel
 import com.github.sdpteam15.polyevents.viewmodel.EventLocalViewModelFactory
-import java.time.LocalDateTime
 import kotlinx.coroutines.Dispatchers
+import java.time.LocalDateTime
 
 /**
  * An activity containing events description. Note that information about the event could be stored from the local
@@ -202,8 +202,8 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
     /**
      * Updates the number of reviews on the xml
      */
-    private fun updateNumberReviews(){
-        if(!PolyEventsApplication.inTest) {
+    private fun updateNumberReviews() {
+        if (!PolyEventsApplication.inTest) {
             PolyEventsApplication.application.applicationScope.launch(Dispatchers.Main) {
                 findViewById<TextView>(R.id.id_number_reviews).text = obsComments.size.toString()
             }
@@ -213,10 +213,11 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
     /**
      * Updates the number of comments on the xml
      */
-    private fun updateNumberComments(){
-        if(!PolyEventsApplication.inTest) {
+    private fun updateNumberComments() {
+        if (!PolyEventsApplication.inTest) {
             PolyEventsApplication.application.applicationScope.launch(Dispatchers.Main) {
-                findViewById<TextView>(R.id.id_number_comments).text = obsNonEmptyComments.size.toString()
+                findViewById<TextView>(R.id.id_number_comments).text =
+                    obsNonEmptyComments.size.toString()
             }
         }
     }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/view/activity/EventActivity.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/view/activity/EventActivity.kt
@@ -15,6 +15,7 @@ import com.github.sdpteam15.polyevents.helper.HelperFunctions
 import com.github.sdpteam15.polyevents.helper.HelperFunctions.showToast
 import com.github.sdpteam15.polyevents.helper.NotificationsHelper
 import com.github.sdpteam15.polyevents.helper.NotificationsScheduler
+import com.github.sdpteam15.polyevents.model.callback.ReviewHasChanged
 import com.github.sdpteam15.polyevents.model.database.local.entity.EventLocal
 import com.github.sdpteam15.polyevents.model.database.local.room.LocalDatabase
 import com.github.sdpteam15.polyevents.model.database.remote.Database.currentDatabase
@@ -28,7 +29,6 @@ import com.github.sdpteam15.polyevents.view.PolyEventsApplication
 import com.github.sdpteam15.polyevents.view.adapter.CommentItemAdapter
 import com.github.sdpteam15.polyevents.view.fragments.EXTRA_EVENT_ID
 import com.github.sdpteam15.polyevents.view.fragments.LeaveEventReviewFragment
-import com.github.sdpteam15.polyevents.model.callback.ReviewHasChanged
 import com.github.sdpteam15.polyevents.view.fragments.ProgressDialogFragment
 import com.github.sdpteam15.polyevents.viewmodel.EventLocalViewModel
 import com.github.sdpteam15.polyevents.viewmodel.EventLocalViewModelFactory
@@ -170,7 +170,7 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
     /**
      * Sets the observe add and modify of the observable list of reviews
      */
-    private fun setObservers(){
+    private fun setObservers() {
         obsComments.observeAdd(this) {
             //If the comment doesn't have a review, we don't want to display it
             if (it.value.feedback != "") {
@@ -178,10 +178,10 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
                 recyclerView.adapter!!.notifyDataSetChanged()
             }
         }
-        obsComments.observe(this){
+        obsComments.observe(this) {
             updateNumberReviews()
         }
-        obsNonEmptyComments.observe(this){
+        obsNonEmptyComments.observe(this) {
             updateNumberComments()
         }
     }
@@ -209,8 +209,8 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
     /**
      * Updates the number of reviews on the xml
      */
-    private fun updateNumberReviews(){
-        if(!PolyEventsApplication.inTest) {
+    private fun updateNumberReviews() {
+        if (!PolyEventsApplication.inTest) {
             PolyEventsApplication.application.applicationScope.launch {
                 findViewById<TextView>(R.id.id_number_reviews).text = obsComments.size.toString()
             }
@@ -220,10 +220,11 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
     /**
      * Updates the number of comments on the xml
      */
-    private fun updateNumberComments(){
-        if(!PolyEventsApplication.inTest) {
+    private fun updateNumberComments() {
+        if (!PolyEventsApplication.inTest) {
             PolyEventsApplication.application.applicationScope.launch {
-                findViewById<TextView>(R.id.id_number_comments).text = obsNonEmptyComments.size.toString()
+                findViewById<TextView>(R.id.id_number_comments).text =
+                    obsNonEmptyComments.size.toString()
             }
         }
     }

--- a/app/src/main/java/com/github/sdpteam15/polyevents/view/activity/EventActivity.kt
+++ b/app/src/main/java/com/github/sdpteam15/polyevents/view/activity/EventActivity.kt
@@ -42,24 +42,6 @@ import java.time.LocalDateTime
  */
 class EventActivity : AppCompatActivity(), ReviewHasChanged {
     // TODO: view on map functionality?
-
-    companion object {
-        const val TAG = "EventActivity"
-
-        // Refactored here for tests
-        val obsEvent: Observable<Event> = Observable()
-        val obsRating: Observable<Float> = Observable()
-        val obsOrganiser: Observable<UserEntity> = Observable()
-        val obsComments: ObservableList<Rating> = ObservableList()
-        lateinit var event: Event
-
-        // Keep an instance for testing purposes
-        lateinit var database: LocalDatabase
-
-        // Keep an instance for testing purposes
-        lateinit var notificationsScheduler: NotificationsScheduler
-    }
-
     private lateinit var eventId: String
 
     private lateinit var subscribeButton: Button
@@ -411,52 +393,18 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
         val (eventBeforeNotificationId, eventStartNotificationId) =
             scheduleNotificationWithRespectToCurrentTime(
                 event = event,
-                LocalDateTime.now()
+                currentTime = LocalDateTime.now(),
+                beforeEventNotificationMessage = getString(
+                    R.string.event_start_soon,
+                    event.eventName
+                ),
+                startTimeNotificationMessage = getString(R.string.event_started, event.eventName)
             )
         // Save the event in the local cache, along its associated notifications ids, to easily
         // retrieve these notifications later (to cancel for example)
         eventLocalInstance.eventBeforeNotificationId = eventBeforeNotificationId
         eventLocalInstance.eventStartNotificationId = eventStartNotificationId
         localEventViewModel.insert(eventLocalInstance)
-    }
-
-    /**
-     * Helper function to schedule notifications for an event at a certain time based on the current time
-     * If the event end time has already passed, no notifications are scheduled. Otherwise if
-     * the event has already started, schedule one notification. Otherwise two notifications, one
-     * before and another after the event.
-     * @param event the event we're scheduling notifications for
-     * @param currentTime the current time from which we're scheduling notifications for this event
-     * @return Pair with first the notification id (if not null) set before the start of the event
-     * and the other (if not null) at the start of the event
-     */
-    fun scheduleNotificationWithRespectToCurrentTime(event: Event, currentTime: LocalDateTime): Pair<Int?, Int?> {
-        var event15MinBeforeNotificationId: Int? = null
-        var eventStartNotificationId: Int? = null
-        // Check first if event has already ended, thus don't send notifications
-        if (!currentTime.isAfter(event.endTime)) {
-
-            // Check if event hasn't already started, schedule a notification 15 min before the start of the event
-            if (LocalDateTime.now().isBefore(event.startTime)) {
-                val event15MinBeforeNotificationMessage =
-                    getString(R.string.event_start_soon, event.eventName)
-                event15MinBeforeNotificationId = notificationsScheduler.scheduleEventNotification(
-                    eventId = event.eventId!!,
-                    notificationMessage = event15MinBeforeNotificationMessage,
-                    scheduledTime = event.startTime!!.minusMinutes(15L)
-                )
-            }
-
-            // Schedule a notification at the start of the event
-            val eventStartNotificationMessage =
-                getString(R.string.event_started, event.eventName)
-            eventStartNotificationId = notificationsScheduler.scheduleEventNotification(
-                eventId = event.eventId!!,
-                notificationMessage = eventStartNotificationMessage,
-                scheduledTime = event.startTime!!
-            )
-        }
-        return Pair(event15MinBeforeNotificationId, eventStartNotificationId)
     }
 
     /**
@@ -475,6 +423,74 @@ class EventActivity : AppCompatActivity(), ReviewHasChanged {
 
     override fun onLeaveReview() {
         refreshEvent()
+    }
+
+
+    companion object {
+        const val TAG = "EventActivity"
+
+        // Refactored here for tests
+        val obsEvent: Observable<Event> = Observable()
+        val obsRating: Observable<Float> = Observable()
+        val obsOrganiser: Observable<UserEntity> = Observable()
+        val obsComments: ObservableList<Rating> = ObservableList()
+        lateinit var event: Event
+
+        // Keep an instance for testing purposes
+        lateinit var database: LocalDatabase
+
+        // Keep an instance for testing purposes
+        lateinit var notificationsScheduler: NotificationsScheduler
+
+        /**
+         * Helper function to schedule notifications for an event at a certain time based on the current time
+         * If the event end time has already passed, no notifications are scheduled. Otherwise if
+         * the event has already started, schedule one notification. Otherwise two notifications, one
+         * before and another after the event.
+         * @param event the event we're scheduling notifications for
+         * @param currentTime the current time from which we're scheduling notifications for this event
+         * @param beforeEventNotificationMessage the message to be displayed in the notification popped
+         * shortly before the start of the event
+         * @param startTimeNotificationMessage the message to be displayed in the notification popped
+         * at the start of the event
+         * @return Pair with first the notification id (if not null) set before the start of the event
+         * and the other (if not null) at the start of the event
+         */
+        fun scheduleNotificationWithRespectToCurrentTime(
+            event: Event,
+            currentTime: LocalDateTime,
+            beforeEventNotificationMessage: String,
+            startTimeNotificationMessage: String
+        ): Pair<Int?, Int?> {
+            var event15MinBeforeNotificationId: Int? = null
+            var eventStartNotificationId: Int? = null
+            // Check first if event has already ended, thus don't send notifications
+            if (!currentTime.isAfter(event.endTime)) {
+
+                // Check if event hasn't already started, schedule a notification 15 min before the start of the event
+                if (currentTime.isBefore(event.startTime)) {
+                    val event15MinBeforeNotificationMessage =
+                        beforeEventNotificationMessage
+                    event15MinBeforeNotificationId =
+                        notificationsScheduler.scheduleEventNotification(
+                            eventId = event.eventId!!,
+                            notificationMessage = event15MinBeforeNotificationMessage,
+                            scheduledTime = event.startTime!!.minusMinutes(15L)
+                        )
+                }
+
+                // Schedule a notification at the start of the event
+                val eventStartNotificationMessage =
+                    startTimeNotificationMessage
+                eventStartNotificationId = notificationsScheduler.scheduleEventNotification(
+                    eventId = event.eventId!!,
+                    notificationMessage = eventStartNotificationMessage,
+                    scheduledTime = event.startTime!!
+                )
+            }
+            return Pair(event15MinBeforeNotificationId, eventStartNotificationId)
+        }
+
     }
 
 }


### PR DESCRIPTION
This PR introduces some improvements:
- Notifications are now scheduled only after event has started or just before it (but not after the event is over)
- added application icon to the notifications
- In events list fragment, filter out events that are over, and sort events in starting time